### PR TITLE
Handle response read errors in OpenAI client

### DIFF
--- a/internal/openai/client_test.go
+++ b/internal/openai/client_test.go
@@ -1,0 +1,50 @@
+package openai
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+type errReader struct {
+	closed bool
+	read   bool
+}
+
+func (e *errReader) Read(p []byte) (int, error) {
+	if e.read {
+		return 0, errors.New("read error")
+	}
+	e.read = true
+	copy(p, []byte("partial"))
+	return len("partial"), errors.New("read error")
+}
+
+func (e *errReader) Close() error {
+	e.closed = true
+	return nil
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestChatReadError(t *testing.T) {
+	er := &errReader{}
+	client := &Client{
+		APIKey: "test",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: 200, Body: er, Header: make(http.Header)}, nil
+		})},
+		BaseURL: "http://example.com",
+	}
+	_, err := client.Chat(ChatCompletionRequest{Model: "gpt-3.5", Messages: []Message{{Role: "user", Content: "hi"}}})
+	if err == nil || err.Error() != "read response body: read error" {
+		t.Fatalf("expected read error, got %v", err)
+	}
+	if !er.closed {
+		t.Fatalf("response body not closed")
+	}
+}


### PR DESCRIPTION
## Summary
- capture and return errors from io.ReadAll while closing the response body
- add test ensuring read errors bubble up and bodies are closed

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68b587883cf88320ba3f70017c1bc04a