### PR TITLE
Use t.Setenv in tests to avoid env leakage

### DIFF
--- a/internal/commit/generator_test.go
+++ b/internal/commit/generator_test.go
@@ -1,24 +1,33 @@
 package commit
 
 import (
-	"os"
 	"testing"
 )
 
 // NOTE: This test only validates configuration parsing without calling the API.
 func TestLoadConfig(t *testing.T) {
-	os.Setenv("AIC_MODEL", "test-model")
-	os.Setenv("AIC_SUGGESTIONS", "10")
+	t.Setenv("AIC_MODEL", "test-model")
+	t.Setenv("AIC_SUGGESTIONS", "10")
 	cfg, _ := LoadConfig("extra")
-	if cfg.Model != "test-model" { t.Fatalf("expected model override, got %s", cfg.Model) }
-	if cfg.Suggestions != 10 { t.Fatalf("expected suggestions=10 got %d", cfg.Suggestions) }
-	if cfg.SystemAddition != "extra" { t.Fatalf("system addition mismatch") }
+	if cfg.Model != "test-model" {
+		t.Fatalf("expected model override, got %s", cfg.Model)
+	}
+	if cfg.Suggestions != 10 {
+		t.Fatalf("expected suggestions=10 got %d", cfg.Suggestions)
+	}
+	if cfg.SystemAddition != "extra" {
+		t.Fatalf("system addition mismatch")
+	}
 }
 
 func TestLoadConfigBounds(t *testing.T) {
-	os.Setenv("AIC_MODEL", "")
-	os.Setenv("AIC_SUGGESTIONS", "999") // out of range, should fallback
+	t.Setenv("AIC_MODEL", "")
+	t.Setenv("AIC_SUGGESTIONS", "999") // out of range, should fallback
 	cfg, _ := LoadConfig("")
-	if cfg.Suggestions != defaultSuggestions { t.Fatalf("expected default suggestions, got %d", cfg.Suggestions) }
-	if cfg.Model != defaultModel { t.Fatalf("expected default model, got %s", cfg.Model) }
+	if cfg.Suggestions != defaultSuggestions {
+		t.Fatalf("expected default suggestions, got %d", cfg.Suggestions)
+	}
+	if cfg.Model != defaultModel {
+		t.Fatalf("expected default model, got %s", cfg.Model)
+	}
 }


### PR DESCRIPTION
## Summary
- replace `os.Setenv` with `t.Setenv` in generator tests to isolate env vars

## Testing
- `go test ./...`
- `go test ./internal/commit -run TestLoadConfig -count=1`
- `go test ./internal/commit -run TestLoadConfigBounds -count=1`


------
https://chatgpt.com/codex/tasks/task_b_68b58792ce2483208fab82a7691049ad