### PR TITLE
feat: add multi-repo style memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ git commit -m aic
 - CI‑ready: non‑interactive mode and optional auto‑commit.
 - Large diffs: structured summary plus clearly truncated raw diff with cutoff notes.
 - Mock mode: `AIC_MOCK=1` for deterministic, offline suggestions.
-- AI‑powered analyze: learns your repo’s style from `git log` and writes a repo `.aic.json` `instructions` used for future commits (merged with home `~/.aic.json` and `-s`).
+- AI‑powered analyze: learns your repo’s style from `git log`, saves it to a global multi‑repo memory, and writes a repo `.aic.json` `instructions` used for future commits (merged with home `~/.aic.json` and `-s`).
 
 <details>
 <summary><strong>Install</strong></summary>
@@ -68,7 +68,7 @@ xattr -d com.apple.quarantine /usr/local/bin/aic 2>/dev/null || true
 <details>
 <summary><strong>Analyze</strong></summary>
 
-Use AI to infer your repository’s commit message conventions and save them as repo‑local presets.
+Use AI to infer your repository’s commit message conventions and save them to a global style memory keyed by repo (and to a repo‑local preset if desired).
 
 Usage:
 
@@ -79,14 +79,14 @@ aic analyze [--limit N]   # default N=1000 recent subjects
 What it does:
 
 - Reads recent non‑merge commit subjects and asks your configured provider to synthesize concise style instructions.
-- Writes/updates `<repo>/.aic.json` with an `instructions` string.
-- These repo instructions are merged with home `~/.aic.json` and CLI `-s` in this order: repo → home → CLI.
+- Writes/updates `<repo>/.aic.json` with an `instructions` string and caches the style in `~/.aic-styles.json` for automatic use across repos.
+- These repo instructions are merged with home `~/.aic.json` and CLI `-s` in this order: repo style memory → repo `.aic.json` → home → CLI.
 
 Notes:
 
 - Requires a provider API key (OpenAI, Claude, Gemini, or Custom) set in the environment.
 - Only commit subjects are sent (no bodies) to minimize prompt size.
-- You can tweak `.aic.json` manually after generation.
+- You can tweak `.aic.json` or `~/.aic-styles.json` manually after generation.
 
 </details>
 

--- a/cmd/aic/main.go
+++ b/cmd/aic/main.go
@@ -30,34 +30,34 @@ func main() {
 	// Soft warning for unknown/unused AIC_* variables to catch typos/misconfig
 	config.WarnUnknownAICEnv()
 
-    // Simple, robust flag parsing (skips consumed values)
-    for i := 0; i < len(args); i++ {
-        arg := args[i]
-        switch {
-        case arg == "-h" || arg == "--help" || arg == "help":
-            fmt.Print(buildHelp())
-            return
-        case arg == "--version" || arg == "-v":
-            fmt.Printf("aic %s\n", version.Get())
-            return
-        case arg == "--no-color":
-            cli.DisableColors()
-        case strings.HasPrefix(arg, "--hook="):
-            hookFile = strings.TrimPrefix(arg, "--hook=")
-        case arg == "--hook":
-            if i+1 < len(args) {
-                hookFile = args[i+1]
-                i++
-            }
-        case strings.HasPrefix(arg, "-s="):
-            systemAddition = strings.TrimPrefix(arg, "-s=")
-        case arg == "-s":
-            if i+1 < len(args) {
-                systemAddition = args[i+1]
-                i++
-            }
-        }
-    }
+	// Simple, robust flag parsing (skips consumed values)
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			fmt.Print(buildHelp())
+			return
+		case arg == "--version" || arg == "-v":
+			fmt.Printf("aic %s\n", version.Get())
+			return
+		case arg == "--no-color":
+			cli.DisableColors()
+		case strings.HasPrefix(arg, "--hook="):
+			hookFile = strings.TrimPrefix(arg, "--hook=")
+		case arg == "--hook":
+			if i+1 < len(args) {
+				hookFile = args[i+1]
+				i++
+			}
+		case strings.HasPrefix(arg, "-s="):
+			systemAddition = strings.TrimPrefix(arg, "-s=")
+		case arg == "-s":
+			if i+1 < len(args) {
+				systemAddition = args[i+1]
+				i++
+			}
+		}
+	}
 
 	cfg, err := commit.LoadConfig(systemAddition)
 	if err != nil {
@@ -116,42 +116,43 @@ func main() {
 }
 
 func runAnalyze(args []string) {
-    // Defaults
-    limit := 1000
-    // Allow simple flag: --limit N
-    for i := 0; i < len(args); i++ {
-        if args[i] == "--limit" && i+1 < len(args) {
-            if n, err := strconv.Atoi(args[i+1]); err == nil && n > 0 {
-                limit = n
-            }
-            i++
-        }
-    }
-    // Build a config without extra instructions to avoid biasing analysis
-    cfg, err := commit.LoadConfig("")
-    if err != nil {
-        fatal(err)
-    }
-    var apiKey string
-    switch cfg.Provider {
-    case "claude":
-        apiKey = config.Get(config.EnvClaudeAPIKey)
-    case "gemini":
-        apiKey = config.Get(config.EnvGeminiAPIKey)
-    case "custom":
-        apiKey = config.Get(config.EnvCustomAPIKey)
-    default:
-        apiKey = config.Get(config.EnvOpenAIAPIKey)
-    }
-    res, err := analyze.Analyze(limit, cfg, apiKey)
-    if err != nil {
-        fatal(err)
-    }
-    if err := config.SaveRepoInstructions(res.Instructions); err != nil {
-        fatal(err)
-    }
-    fmt.Printf("%s%s Wrote repo .aic.json%s\n", cli.ColorGray, cli.ColorBold, cli.ColorReset)
-    fmt.Printf("  %sAnalyzed %d commit subjects and generated style instructions.%s\n", cli.ColorDim, res.SampleTotal, cli.ColorReset)
+	// Defaults
+	limit := 1000
+	// Allow simple flag: --limit N
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--limit" && i+1 < len(args) {
+			if n, err := strconv.Atoi(args[i+1]); err == nil && n > 0 {
+				limit = n
+			}
+			i++
+		}
+	}
+	// Build a config without extra instructions to avoid biasing analysis
+	cfg, err := commit.LoadConfig("")
+	if err != nil {
+		fatal(err)
+	}
+	var apiKey string
+	switch cfg.Provider {
+	case "claude":
+		apiKey = config.Get(config.EnvClaudeAPIKey)
+	case "gemini":
+		apiKey = config.Get(config.EnvGeminiAPIKey)
+	case "custom":
+		apiKey = config.Get(config.EnvCustomAPIKey)
+	default:
+		apiKey = config.Get(config.EnvOpenAIAPIKey)
+	}
+	res, err := analyze.Analyze(limit, cfg, apiKey)
+	if err != nil {
+		fatal(err)
+	}
+	if err := config.SaveRepoInstructions(res.Instructions); err != nil {
+		fatal(err)
+	}
+	_ = config.SaveRepoStyle(res.Instructions, res.Embedding)
+	fmt.Printf("%s%s Wrote repo .aic.json%s\n", cli.ColorGray, cli.ColorBold, cli.ColorReset)
+	fmt.Printf("  %sAnalyzed %d commit subjects and generated style instructions.%s\n", cli.ColorDim, res.SampleTotal, cli.ColorReset)
 }
 
 func buildHelp() string {
@@ -176,9 +177,9 @@ func buildHelp() string {
 	b.WriteString(fmt.Sprintf("%sUsage%s:\n", cli.ColorBold, cli.ColorReset))
 	b.WriteString("  aic [-s \"extra instruction\"] [--version] [--no-color]\n\n")
 	b.WriteString(fmt.Sprintf("%sDescription%s:\n", cli.ColorBold, cli.ColorReset))
-    b.WriteString("  Generates concise, natural-language Git commit messages based on your staged changes.\n")
-    b.WriteString("  It requests suggestions from an AI model, lets you choose one, then offers to commit.\n")
-    b.WriteString("  Also includes 'aic analyze' to infer repo style and write .aic.json presets.\n\n")
+	b.WriteString("  Generates concise, natural-language Git commit messages based on your staged changes.\n")
+	b.WriteString("  It requests suggestions from an AI model, lets you choose one, then offers to commit.\n")
+	b.WriteString("  Also includes 'aic analyze' to infer repo style and write .aic.json presets.\n\n")
 	b.WriteString(fmt.Sprintf("%sArguments & Environment%s:\n", cli.ColorBold, cli.ColorReset))
 	for _, r := range rows {
 		pad := strings.Repeat(" ", maxVar-len(r[0]))

--- a/internal/analyze/analyze.go
+++ b/internal/analyze/analyze.go
@@ -1,10 +1,10 @@
 package analyze
 
 import (
-    "bytes"
-    "fmt"
-    "os/exec"
-    "strings"
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
 
 	"github.com/diesi/aic/internal/commit"
 	"github.com/diesi/aic/internal/openai"
@@ -15,6 +15,7 @@ import (
 type Result struct {
 	Instructions string
 	SampleTotal  int
+	Embedding    []float64
 }
 
 // Note: commit subject parsing patterns were removed; future refinements may reintroduce them as needed.
@@ -27,11 +28,23 @@ func Analyze(limit int, cfg commit.Config, apiKey string) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	instr, err := generateInstructions(cfg, apiKey, subjects)
+	var p provider.Provider
+	switch cfg.Provider {
+	case "claude":
+		p = provider.NewClaude(apiKey)
+	case "gemini":
+		p = provider.NewGemini(apiKey)
+	case "custom":
+		p = provider.NewCustom(apiKey)
+	default:
+		p = provider.NewOpenAI(apiKey)
+	}
+	instr, err := generateInstructions(p, cfg.Model, subjects)
 	if err != nil {
 		return Result{}, err
 	}
-	return Result{Instructions: instr, SampleTotal: len(subjects)}, nil
+	emb, _ := p.Embed(instr)
+	return Result{Instructions: instr, SampleTotal: len(subjects), Embedding: emb}, nil
 }
 
 // collectSubjects returns recent non-merge commit subjects (one per line, trimmed).
@@ -61,35 +74,23 @@ func collectSubjects(limit int) ([]string, error) {
 
 // generateInstructions prompts the AI model to output a single, concise
 // instruction string for commit style based on the given subjects.
-func generateInstructions(cfg commit.Config, apiKey string, subjects []string) (string, error) {
-    if len(subjects) == 0 {
-        // With no commits, fall back to a generic instruction set favoring natural language subjects
-        return "Write concise, natural-language commit subjects in imperative mood (<=72 chars, no trailing period).", nil
-    }
-
-	var p provider.Provider
-	switch cfg.Provider {
-	case "claude":
-		p = provider.NewClaude(apiKey)
-	case "gemini":
-		p = provider.NewGemini(apiKey)
-	case "custom":
-		p = provider.NewCustom(apiKey)
-	default:
-		p = provider.NewOpenAI(apiKey)
+func generateInstructions(p provider.Provider, model string, subjects []string) (string, error) {
+	if len(subjects) == 0 {
+		// With no commits, fall back to a generic instruction set favoring natural language subjects
+		return "Write concise, natural-language commit subjects in imperative mood (<=72 chars, no trailing period).", nil
 	}
 
-    // Prepare the prompt. Ask for a single, compact instruction set for .aic.json.
-    system := "You analyze Git commit history and produce a concise, prescriptive style guide for future commit messages. " +
-        "Infer conventions actually used (types like feat|fix|docs|refactor|chore|test|perf|build|ci|style; whether scope is used; whether subjects end with a period; imperative mood; <=72 char subject). " +
-        "Also infer the dominant natural language of the subjects (e.g., English, Spanish, German) and include a brief directive to write messages in that language (e.g., 'Write messages in English.'). " +
-        "Output only the final instruction text suitable for a config file; do not include examples, lists, or the analyzed messages."
+	// Prepare the prompt. Ask for a single, compact instruction set for .aic.json.
+	system := "You analyze Git commit history and produce a concise, prescriptive style guide for future commit messages. " +
+		"Infer conventions actually used (types like feat|fix|docs|refactor|chore|test|perf|build|ci|style; whether scope is used; whether subjects end with a period; imperative mood; <=72 char subject). " +
+		"Also infer the dominant natural language of the subjects (e.g., English, Spanish, German) and include a brief directive to write messages in that language (e.g., 'Write messages in English.'). " +
+		"Output only the final instruction text suitable for a config file; do not include examples, lists, or the analyzed messages."
 	// Join subjects in a compact block. We only pass subjects, not bodies.
 	user := "Recent commit subjects (one per line):\n" + strings.Join(subjects, "\n")
 
 	temp := float32(0.3)
 	req := openai.ChatCompletionRequest{
-		Model:       cfg.Model,
+		Model:       model,
 		Messages:    []openai.Message{{Role: "system", Content: system}, {Role: "user", Content: user}},
 		MaxTokens:   280,
 		N:           1,

--- a/internal/commit/config.go
+++ b/internal/commit/config.go
@@ -1,11 +1,11 @@
 package commit
 
 import (
-    "fmt"
-    "os"
-    "strings"
+	"fmt"
+	"os"
+	"strings"
 
-    "github.com/diesi/aic/internal/config"
+	"github.com/diesi/aic/internal/config"
 )
 
 const (
@@ -38,31 +38,36 @@ type Config struct {
 }
 
 func LoadConfig(systemAddition string) (Config, error) {
-    // Load optional repo and user instructions and merge with CLI-provided additions.
-    // Merge order (lowest -> highest precedence): repo, home, CLI.
-    // The final string concatenates non-empty parts with spaces.
-    parts := []string{}
-    rc := config.LoadRepoConfig()
-    uc := config.LoadUserConfig()
-    if rc.Instructions != "" {
-        parts = append(parts, rc.Instructions)
-    }
-    if uc.Instructions != "" {
-        parts = append(parts, uc.Instructions)
-    }
-    if strings.TrimSpace(systemAddition) != "" {
-        parts = append(parts, strings.TrimSpace(systemAddition))
-    }
-    systemAddition = strings.TrimSpace(strings.Join(parts, " "))
+	// Load optional repo and user instructions and merge with CLI-provided additions.
+	// Merge order (lowest -> highest precedence): repo, home, CLI.
+	// The final string concatenates non-empty parts with spaces.
+	parts := []string{}
+	// Repo-specific style memory takes precedence over repo .aic.json.
+	sm := config.LoadRepoStyle()
+	rc := config.LoadRepoConfig()
+	uc := config.LoadUserConfig()
+	if sm.Instructions != "" {
+		parts = append(parts, sm.Instructions)
+	} else if rc.Instructions != "" {
+		parts = append(parts, rc.Instructions)
+	}
+	if uc.Instructions != "" {
+		parts = append(parts, uc.Instructions)
+	}
+	if strings.TrimSpace(systemAddition) != "" {
+		parts = append(parts, strings.TrimSpace(systemAddition))
+	}
+	systemAddition = strings.TrimSpace(strings.Join(parts, " "))
 
-    if config.Bool(config.EnvAICDebug) {
-        if config.Bool(config.EnvAICDisableRepoConfig) {
-            fmt.Fprintln(os.Stderr, "[aic][debug] repo config disabled via AIC_DISABLE_REPO_CONFIG=1")
-        }
-        fmt.Fprintf(os.Stderr, "[aic][debug] repo .aic.json instructions: %q\n", rc.Instructions)
-        fmt.Fprintf(os.Stderr, "[aic][debug] home ~/.aic.json instructions: %q\n", uc.Instructions)
-        fmt.Fprintf(os.Stderr, "[aic][debug] merged instructions: %q\n", systemAddition)
-    }
+	if config.Bool(config.EnvAICDebug) {
+		if config.Bool(config.EnvAICDisableRepoConfig) {
+			fmt.Fprintln(os.Stderr, "[aic][debug] repo config disabled via AIC_DISABLE_REPO_CONFIG=1")
+		}
+		fmt.Fprintf(os.Stderr, "[aic][debug] repo style memory instructions: %q\n", sm.Instructions)
+		fmt.Fprintf(os.Stderr, "[aic][debug] repo .aic.json instructions: %q\n", rc.Instructions)
+		fmt.Fprintf(os.Stderr, "[aic][debug] home ~/.aic.json instructions: %q\n", uc.Instructions)
+		fmt.Fprintf(os.Stderr, "[aic][debug] merged instructions: %q\n", systemAddition)
+	}
 	providerName := strings.ToLower(config.Get(config.EnvAICProvider))
 	if providerName == "" {
 		// Auto-detect provider from available API keys when AIC_PROVIDER is unset.

--- a/internal/config/stylememory.go
+++ b/internal/config/stylememory.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type repoStyle struct {
+	Instructions string    `json:"instructions"`
+	Embedding    []float64 `json:"embedding,omitempty"`
+}
+
+type styleMemory struct {
+	Repos map[string]repoStyle `json:"repos"`
+}
+
+func styleMemoryPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return ""
+	}
+	return filepath.Join(home, ".aic-styles.json")
+}
+
+// LoadRepoStyle returns the stored style instructions for the current repository, if any.
+func LoadRepoStyle() UserConfig {
+	root := repoRoot()
+	if root == "" {
+		return UserConfig{}
+	}
+	path := styleMemoryPath()
+	if path == "" {
+		return UserConfig{}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return UserConfig{}
+	}
+	var sm styleMemory
+	if err := json.Unmarshal(data, &sm); err != nil {
+		return UserConfig{}
+	}
+	if sm.Repos == nil {
+		return UserConfig{}
+	}
+	rs, ok := sm.Repos[root]
+	if !ok {
+		return UserConfig{}
+	}
+	return UserConfig{Instructions: strings.TrimSpace(rs.Instructions)}
+}
+
+// SaveRepoStyle stores instructions and optional embedding for the current repo in the style memory file.
+func SaveRepoStyle(instructions string, embedding []float64) error {
+	root := repoRoot()
+	if root == "" {
+		return fmt.Errorf("not a git repository; cannot locate repo root")
+	}
+	path := styleMemoryPath()
+	if path == "" {
+		return fmt.Errorf("cannot determine home directory")
+	}
+	instructions = strings.TrimSpace(instructions)
+	var sm styleMemory
+	if b, err := os.ReadFile(path); err == nil && len(b) > 0 {
+		_ = json.Unmarshal(b, &sm) // best effort
+	}
+	if sm.Repos == nil {
+		sm.Repos = map[string]repoStyle{}
+	}
+	sm.Repos[root] = repoStyle{Instructions: instructions, Embedding: embedding}
+	out, err := json.MarshalIndent(sm, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, out, 0o644)
+}

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -97,3 +97,42 @@ func (c *Client) Chat(req ChatCompletionRequest) (*ChatCompletionResponse, error
 		return &completion, nil
 	}
 }
+
+// Embeddings requests an embedding vector for the given input text.
+func (c *Client) Embeddings(req EmbeddingsRequest) (*EmbeddingsResponse, error) {
+	bodyBytes, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	endpoint := c.BaseURL + "/embeddings"
+	httpReq, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("new request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+c.APIKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := c.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	respBody, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+	if readErr != nil {
+		return nil, fmt.Errorf("read response body: %w", readErr)
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("close response body: %w", closeErr)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("openai embeddings http %d: %s", resp.StatusCode, string(respBody))
+	}
+	var emb EmbeddingsResponse
+	if err := json.Unmarshal(respBody, &emb); err != nil {
+		return nil, fmt.Errorf("unmarshal response: %w", err)
+	}
+	emb.Raw = string(respBody)
+	if emb.Error.Message != "" {
+		return nil, fmt.Errorf("openai error: %s", emb.Error.Message)
+	}
+	return &emb, nil
+}

--- a/internal/openai/types.go
+++ b/internal/openai/types.go
@@ -28,3 +28,20 @@ type ChatCompletionResponse struct {
 	} `json:"error"`
 	Raw string `json:"-"`
 }
+
+// EmbeddingsRequest represents the OpenAI embeddings request payload.
+type EmbeddingsRequest struct {
+	Model string `json:"model"`
+	Input string `json:"input"`
+}
+
+// EmbeddingsResponse represents the OpenAI embeddings response payload.
+type EmbeddingsResponse struct {
+	Data []struct {
+		Embedding []float64 `json:"embedding"`
+	} `json:"data"`
+	Error struct {
+		Message string `json:"message"`
+	} `json:"error"`
+	Raw string `json:"-"`
+}

--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -118,3 +118,8 @@ func (c *Claude) Chat(req openai.ChatCompletionRequest) (*CompletionResponse, er
 
 	return &CompletionResponse{Choices: choices, Raw: strings.Join(rawParts, "\n")}, nil
 }
+
+// Embed is not supported for Claude and returns an error.
+func (c *Claude) Embed(text string) ([]float64, error) {
+	return nil, fmt.Errorf("embeddings not supported")
+}

--- a/internal/provider/custom.go
+++ b/internal/provider/custom.go
@@ -216,6 +216,57 @@ func (c *Custom) Chat(req openai.ChatCompletionRequest) (*CompletionResponse, er
 	}
 }
 
+// Embed sends text to the custom server's embeddings endpoint and returns the vector.
+func (c *Custom) Embed(text string) ([]float64, error) {
+	body := map[string]any{"input": text}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	endpoint := c.endpoint(c.EmbeddingsPath)
+	httpReq, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("new request: %w", err)
+	}
+	if c.APIKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+c.APIKey)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := c.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	respBody, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+	if readErr != nil {
+		return nil, fmt.Errorf("read response body: %w", readErr)
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("close response body: %w", closeErr)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("custom embeddings http %d: %s", resp.StatusCode, string(respBody))
+	}
+	var out struct {
+		Data []struct {
+			Embedding []float64 `json:"embedding"`
+		} `json:"data"`
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("unmarshal response: %w", err)
+	}
+	if out.Error.Message != "" {
+		return nil, fmt.Errorf("custom error: %s", out.Error.Message)
+	}
+	if len(out.Data) == 0 {
+		return nil, fmt.Errorf("empty embedding response")
+	}
+	return out.Data[0].Embedding, nil
+}
+
 var (
 	// Remove balanced <think>...</think>
 	thinkBalancedRe = regexp.MustCompile(`(?is)<think\b[^>]*>.*?</think>`)

--- a/internal/provider/gemini.go
+++ b/internal/provider/gemini.go
@@ -156,3 +156,8 @@ func (g *Gemini) Chat(req openai.ChatCompletionRequest) (*CompletionResponse, er
 	// Unreachable due to returns in loop
 	return nil, fmt.Errorf("unexpected gemini Chat loop exit")
 }
+
+// Embed is not supported for Gemini and returns an error.
+func (g *Gemini) Embed(text string) ([]float64, error) {
+	return nil, fmt.Errorf("embeddings not supported")
+}

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -1,6 +1,10 @@
 package provider
 
-import "github.com/diesi/aic/internal/openai"
+import (
+	"fmt"
+
+	"github.com/diesi/aic/internal/openai"
+)
 
 // OpenAI implements the Provider interface using the OpenAI API.
 type OpenAI struct {
@@ -24,4 +28,17 @@ func (o *OpenAI) Chat(req openai.ChatCompletionRequest) (*CompletionResponse, er
 		out.Choices = append(out.Choices, c.Message.Content)
 	}
 	return out, nil
+}
+
+// Embed generates an embedding vector for the provided text using OpenAI's embeddings API.
+func (o *OpenAI) Embed(text string) ([]float64, error) {
+	req := openai.EmbeddingsRequest{Model: "text-embedding-3-small", Input: text}
+	resp, err := o.client.Embeddings(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || len(resp.Data) == 0 {
+		return nil, fmt.Errorf("empty embedding response")
+	}
+	return resp.Data[0].Embedding, nil
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -11,4 +11,5 @@ type CompletionResponse struct {
 // Provider defines the interface for AI providers.
 type Provider interface {
 	Chat(req openai.ChatCompletionRequest) (*CompletionResponse, error)
+	Embed(text string) ([]float64, error)
 }


### PR DESCRIPTION
## Summary
- add global style memory stored in `~/.aic-styles.json` and load it automatically per repo
- compute and store style embeddings during analyze
- expose embedding APIs for OpenAI/custom providers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68c02a7f002883208bf07acd1f881dc3