### PR TITLE
docs: add Windows env var examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,16 @@ AI‑assisted git commit message generator with an iterative “combine” workf
 
 ## Quick Start
 
+Set your API key via environment variables. `export` works in Bash shells; PowerShell and CMD equivalents are shown below.
+
 ```bash
 # choose a provider (auto‑detected if set)
+# Bash (Linux/macOS):
 export OPENAI_API_KEY=sk-...   # or: export CLAUDE_API_KEY=sk-... or: export GEMINI_API_KEY=sk-...
+# PowerShell (current session):
+$Env:OPENAI_API_KEY="sk-..."   # or: $Env:CLAUDE_API_KEY="sk-..." or: $Env:GEMINI_API_KEY="sk-..."
+# PowerShell or CMD (persist for new sessions):
+setx OPENAI_API_KEY "sk-..."   # or: setx CLAUDE_API_KEY "sk-..." or: setx GEMINI_API_KEY "sk-..."
 
 # optional: infer this repo's commit style and save .aic.json (used as presets)
 aic analyze


### PR DESCRIPTION
## Summary
- clarify that `export` is for Bash and show PowerShell/CMD equivalents
- add Windows examples for all provider API keys in Quick Start

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68c139b259248320b095ebaa52b6dc08