### PR TITLE
Warn on secrets in staged diff

### DIFF
--- a/internal/commit/generate.go
+++ b/internal/commit/generate.go
@@ -37,13 +37,14 @@ func GenerateSuggestions(cfg Config, apiKey string) ([]string, error) {
 			return nil, errors.New("missing OPENAI_API_KEY")
 		}
 	}
-	gitDiff, err := git.StagedDiff()
-	if err != nil {
-		return nil, err
-	}
-	if strings.TrimSpace(gitDiff) == "" {
-		return nil, errors.New("no staged changes")
-	}
+       gitDiff, err := git.StagedDiff()
+       if err != nil {
+               return nil, err
+       }
+       if strings.TrimSpace(gitDiff) == "" {
+               return nil, errors.New("no staged changes")
+       }
+       warnIfSecrets(gitDiff)
 
 	var p provider.Provider
 	switch cfg.Provider {

--- a/internal/commit/secrets.go
+++ b/internal/commit/secrets.go
@@ -1,0 +1,40 @@
+package commit
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/diesi/aic/internal/cli"
+)
+
+type secretPattern struct {
+	name string
+	re   *regexp.Regexp
+}
+
+var secretPatterns = []secretPattern{
+	{"OpenAI API key", regexp.MustCompile(`sk-[A-Za-z0-9]{16,}`)},
+	{"AWS Access Key", regexp.MustCompile(`AKIA[0-9A-Z]{16}`)},
+	{"Password assignment", regexp.MustCompile(`(?i)password\s*[:=]\s*\S`)},
+	{"Secret assignment", regexp.MustCompile(`(?i)secret\s*[:=]\s*\S`)},
+	{"Private key block", regexp.MustCompile(`-----BEGIN [A-Z ]+PRIVATE KEY-----`)},
+}
+
+func detectSecrets(diff string) []string {
+	matches := []string{}
+	for _, p := range secretPatterns {
+		if p.re.MatchString(diff) {
+			matches = append(matches, p.name)
+		}
+	}
+	return matches
+}
+
+func warnIfSecrets(diff string) {
+	secrets := detectSecrets(diff)
+	if len(secrets) > 0 {
+		fmt.Fprintf(os.Stderr, "%s%s WARNING: possible secrets detected (%s)%s\n", cli.ColorRed, cli.ColorBold, strings.Join(secrets, ", "), cli.ColorReset)
+	}
+}

--- a/internal/commit/secrets_test.go
+++ b/internal/commit/secrets_test.go
@@ -1,0 +1,15 @@
+package commit
+
+import "testing"
+
+func TestDetectSecrets(t *testing.T) {
+	diff := "+ api_key=sk-1234567890abcdef1234567890abcdef\n"
+	matches := detectSecrets(diff)
+	if len(matches) == 0 {
+		t.Fatalf("expected secret detection, got none")
+	}
+	safe := "+ fmt.Println(\"hello\")\n"
+	if m := detectSecrets(safe); len(m) != 0 {
+		t.Fatalf("unexpected secret detection: %v", m)
+	}
+}


### PR DESCRIPTION
## Summary
- warn if staged diff contains potential secrets like API keys or passwords
- add regex-based secret scanning with unit tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68c13c3a29708320abafaab860546d7f